### PR TITLE
Script to restart my_sync_deamon in case of failure.

### DIFF
--- a/mySync/bin/my_sync_guardian.sh
+++ b/mySync/bin/my_sync_guardian.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+trap "pkill -P $$ --signal SIGHUP; pkill -9 -f \"sleep 86400\"; exit" SIGINT SIGHUP
+# Start only when deamon is not running
+while true; do
+    PID=$(pgrep my_sync_de)
+    if [ "${PID}" == "" ]; then
+        break
+    fi
+    sleep 10 &
+    wait $!
+done
+
+# Guard
+while true; do
+    PID=$(pgrep my_sync_de)
+    if [ "${PID}" == "" ]; then
+        ./my_sync_deamon.sh > /dev/null &
+    fi
+    sleep 86400 &
+    wait $!
+done

--- a/mySync/start.sh
+++ b/mySync/start.sh
@@ -5,4 +5,4 @@ path=$1
 
 mkdir -p ~/.config/rclone/
 ln -s /mnt/HD/HD_a2/.systemfile/mySync/etc/rclone.conf ~/.config/rclone/rclone.conf
-cd ${path}/bin; ./my_sync_deamon.sh > /dev/null &
+cd ${path}/bin; ./my_sync_guardian.sh > /dev/null &

--- a/mySync/stop.sh
+++ b/mySync/stop.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # stop.sh: Will stop App daemon.
 
-killall -s SIGHUP my_sync_deamon.sh
+killall -s SIGHUP my_sync_guardian.sh


### PR DESCRIPTION
In case of my_sync_deamon failure the main safeguard should be a notification (TODO).
Issue might be related to blocked remote account and in such case we shouldn't spam retries.
Guardian is a fallback scenario - it will retry only once per day.